### PR TITLE
Add hw kunernetes-intro

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,27 @@
-# Выполнено ДЗ №
+# Выполнено ДЗ №2
 
- - [ ] Основное ДЗ
- - [ ] Задание со *
+ - [*] Основное ДЗ
+ - [*] Задание со *
 
-## В процессе сделано:
- - Пункт 1
- - Пункт 2
+## Что сделано:
+ - Изучена документация, описывающая работу системных подов.
+   kubelet управляет функционированием kube-scheduler, kube-controller-manager, kube-apiserver, etcd, они описаны в манифестах /etc/kubernetes/manifests
+   (https://kubernetes.io/docs/concepts/workloads/pods/#static-pods)
+   kube-proxy контролируется, как DaemonSet на каждой ноде кластера (https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+   coredns запущен как Deployments c ReplicaSet (https://kubernetes.io/docs/concepts/workloads/controllers/deployment)
+ - Собран docker-образ web c web-сервером nginx.
+ - Создан манифест pod'а, создающий init-cintainer c wget для получения контента извне, добавлен общий том emptyDir, доступный для обоих контейнеров, который перед запуском web-сервера загружает статический контент.
+ - kubectl port-forward для работы с подом в режиме отладки
+ - Собран контейнер hipster-frontend
+ - С помощью ad-hock команды контейнер запущен в pod'е kubernetes, также был сгенерирован первичный манифест пода.
+ - В манифест были добавлены переменнеы окружения, необходимые для запуска контейнера.
 
 ## Как запустить проект:
- - Например, запустить команду X в директории Y
+ - kubectl apply -f web-pod.yaml для запуска пода web со статичной станицей
+ - kubectl port-forward --address localhost pod/web 8000 для проверки доступности страницы
 
 ## Как проверить работоспособность:
- - Например, перейти по ссылке http://localhost:8080
+ - wget http://localhost:8000 -O - > /dev/null
 
 ## PR checklist:
- - [ ] Выставлен label с темой домашнего задания
+ - [*] Выставлен label с темой домашнего задания

--- a/README.md
+++ b/README.md
@@ -7,3 +7,16 @@ babenap Platform repository
 **.travis.yml** - необходим для автоматизированной проверки ДЗ
 **.github/PULL*REQUEST*TEMPLATE.md** - шаблон для описания PR
 **.github/auto_assign.yml** - файл конфигурации для плагина **Auto Assign**
+
+### Задание 2
+* Изучена документация, описывающая работу системных подов.
+  kubelet управляет функционированием kube-scheduler, kube-controller-manager, kube-apiserver, etcd, они описаны в манифестах /etc/kubernetes/manifests
+  (https://kubernetes.io/docs/concepts/workloads/pods/#static-pods)
+  kube-proxy контролируется, как DaemonSet на каждой ноде кластера (https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
+  coredns запущен как Deployments c ReplicaSet (https://kubernetes.io/docs/concepts/workloads/controllers/deployment)
+* Собран docker-образ web c web-сервером nginx.
+* Создан манифест pod'а, создающий init-cintainer c wget для получения контента извне, добавлен общий том emptyDir, доступный для обоих контейнеров, который перед запуском web-сервера загружает статический контент.
+* kubectl port-forward для работы с подом в режиме отладки
+* Собран контейнер hipster-frontend
+* С помощью ad-hock команды контейнер запущен в pod'е kubernetes, также был сгенерирован первичный манифест пода.
+* В манифест были добавлены переменнеы окружения, необходимые для запуска контейнера.

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: babench/hipster-frontend:0.1
+    name: frontend
+    env:
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: "productcatalogservice:3001"
+      - name: CURRENCY_SERVICE_ADDR
+        value: "currencyservice:3002"
+      - name: CART_SERVICE_ADDR
+        value: "cartservice:3003"
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: "recommendationservice:3004"
+      - name: SHIPPING_SERVICE_ADDR
+        value: "shippingservice:3005"
+      - name: CHECKOUT_SERVICE_ADDR
+        value: "checkoutservice:3006"
+      - name: AD_SERVICE_ADDR
+        value: "adservice:3007"

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1             # Версия API
+kind: Pod                  # Объект, который создаем
+metadata:
+  name: web                # Название Pod
+  labels:                  # Метки в формате key: value
+    app: web
+spec:                      # Описание Pod
+  containers:              # Описание контейнеров внутри Pod
+  - name: web              # Название контейнера
+    image: babench/web:0.1 # Образ из которого создается контейнер
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  initContainers:
+  - name: init-web
+    image: busybox:1.32
+    command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+    volumeMounts:
+    - name: app
+      mountPath: /app  
+  volumes:
+  - name: app
+    emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,14 @@
+FROM nginx:1.19.5-alpine
+
+RUN apk add --no-cache shadow
+RUN usermod -u 1001 nginx \
+  && groupmod -g 1001 nginx
+
+WORKDIR /app
+COPY ./app .
+
+COPY ./default.conf /etc/nginx/conf.d/default.conf
+COPY ./nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 8000
+USER 1001

--- a/kubernetes-intro/web/app/homework.html
+++ b/kubernetes-intro/web/app/homework.html
@@ -1,0 +1,8 @@
+<HTML>
+    <HEAD>
+        <TITLE>Homework 02</TITLE>
+    </HEAD>
+    <BODY>
+        <H1>Hello world!!!</H1>
+    </BODY>
+</HTML>

--- a/kubernetes-intro/web/default.conf
+++ b/kubernetes-intro/web/default.conf
@@ -1,0 +1,45 @@
+server {
+    listen       8000;
+    listen  [::]:8000;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /app;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,37 @@
+#user  nginx;
+worker_processes  auto;
+
+#error_log  /var/log/nginx/access.log crit;
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log off;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
# Выполнено ДЗ №2

 - [*] Основное ДЗ
 - [*] Задание со *

## Что сделано:
 - Изучена документация, описывающая работу системных подов.
   kubelet управляет функционированием kube-scheduler, kube-controller-manager, kube-apiserver, etcd, они описаны в манифестах /etc/kubernetes/manifests
   (https://kubernetes.io/docs/concepts/workloads/pods/#static-pods)
   kube-proxy контролируется, как DaemonSet на каждой ноде кластера (https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/)
   coredns запущен как Deployments c ReplicaSet (https://kubernetes.io/docs/concepts/workloads/controllers/deployment)
 - Собран docker-образ web c web-сервером nginx.
 - Создан манифест pod'а, создающий init-cintainer c wget для получения контента извне, добавлен общий том emptyDir, доступный для обоих контейнеров, который перед запуском web-сервера загружает статический контент.
 - kubectl port-forward для работы с подом в режиме отладки
 - Собран контейнер hipster-frontend
 - С помощью ad-hock команды контейнер запущен в pod'е kubernetes, также был сгенерирован первичный манифест пода.
 - В манифест были добавлены переменнеы окружения, необходимые для запуска контейнера.

## Как запустить проект:
 - kubectl apply -f web-pod.yaml для запуска пода web со статичной станицей
 - kubectl port-forward --address localhost pod/web 8000 для проверки доступности страницы

## Как проверить работоспособность:
 - wget http://localhost:8000 -O - > /dev/null

## PR checklist:
 - [*] Выставлен label с темой домашнего задания